### PR TITLE
Fixed `--version` and `-v` flags on root cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,8 @@ func RootCommand() *cobra.Command {
 		Short: "Start the worker multiplexer",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if version {
-				return VersionCommand().Execute()
+				printVersion()
+				return nil
 			}
 			q, err := queue.NewRedisQueue(redisHost, redisPassword, redisDb, redisList)
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,11 @@ func VersionCommand() *cobra.Command {
 		Short: "Show the version information",
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Printf("Version: %s\tCommit: %s\n", internal.Version, internal.GitCommit)
+			printVersion()
 		},
 	}
+}
+
+func printVersion() {
+	fmt.Printf("Version: %s\tCommit: %s\n", internal.Version, internal.GitCommit)
 }


### PR DESCRIPTION
Signed-off-by: Shikachuu <zcmate@gmail.com>